### PR TITLE
Fixed bluetooth status call

### DIFF
--- a/ghome/ghome.py
+++ b/ghome/ghome.py
@@ -112,7 +112,7 @@ def bstat(ip):
   try:
     response = requests.request("GET", url).json()
     for key, value in response.items():
-        print key, value
+        print(key, value)
   except Exception as e:
     print(e)
 


### PR DESCRIPTION
Fixed bluetooth status call which was using older style print statement, preventing compatibility with Python 3.8.